### PR TITLE
Fix for ios FB sharing 

### DIFF
--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -9,17 +9,26 @@
 #import "GenericShare.h"
 
 @implementation GenericShare
-    RCT_EXPORT_MODULE();
 - (void)shareSingle:(NSDictionary *)options
     failureCallback:(RCTResponseErrorBlock)failureCallback
     successCallback:(RCTResponseSenderBlock)successCallback
     serviceType:(NSString*)serviceType {
-
+    
+    static BOOL canOpenViaApp;
+    
+    canOpenViaApp = [SLComposeViewController isAvailableForServiceType:serviceType];
+    
+    if ([options[@"social"] isEqualToString:@"facebook"]){
+        canOpenViaApp = [self isAppInstalled:@"fbauth2"];
+    } else if ([options[@"social"] isEqualToString:@"twitter"]){
+        canOpenViaApp = [self isAppInstalled:@"twitterauth"];
+    }
+    
     NSLog(@"Try open view");
-    if([SLComposeViewController isAvailableForServiceType:serviceType]) {
-
+    if(canOpenViaApp) {
+        
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
-
+        
         NSURL *URL = [RCTConvert NSURL:options[@"url"]];
         if (URL) {
             if (URL.fileURL || [URL.scheme.lowercaseString isEqualToString:@"data"]) {
@@ -33,52 +42,63 @@
                 }
                 UIImage *image = [UIImage imageWithData: data];
                 [composeController addImage:image];
-
+                
             } else {
                 [composeController addURL:URL];
             }
         }
-
+        
         if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
             NSString *text = [RCTConvert NSString:options[@"message"]];
             [composeController setInitialText:text];
         }
-
-
+        
+        
         UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
         [ctrl presentViewController:composeController animated:YES completion:Nil];
         successCallback(@[]);
-      } else {
+    } else {
         NSString *errorMessage = @"Not installed";
         NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
         NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-
+        
         NSLog(errorMessage);
         failureCallback(error);
-
+        
         NSString *escapedString = [options[@"message"] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
-
+        
         if ([options[@"social"] isEqualToString:@"twitter"]) {
-          NSString *URL = [NSString stringWithFormat:@"https://twitter.com/intent/tweet?text=%@&url=%@", escapedString, options[@"url"]];
-          [self openScheme:URL];
+            NSString *URL = [NSString stringWithFormat:@"https://twitter.com/intent/tweet?message=%@&url=%@", escapedString, options[@"url"]];
+            [self openScheme:URL];
         }
-
+        
         if ([options[@"social"] isEqualToString:@"facebook"]) {
-          NSString *URL = [NSString stringWithFormat:@"https://www.facebook.com/sharer/sharer.php?u=%@", options[@"url"]];
-          [self openScheme:URL];
+            NSString *URL = [NSString stringWithFormat:@"https://www.facebook.com/sharer/sharer.php?u=%@", options[@"url"]];
+            [self openScheme:URL];
         }
+        
+    }
+}
 
-      }
-  }
-  - (void)openScheme:(NSString *)scheme {
-      UIApplication *application = [UIApplication sharedApplication];
-      NSURL *schemeURL = [NSURL URLWithString:scheme];
+-(BOOL)isAppInstalled:(NSString *)scheme {
+    NSURLComponents *components = [[NSURLComponents alloc] init];
+    components.scheme = scheme;
+    components.path = @"/";
+    return [[UIApplication sharedApplication]
+            canOpenURL:components.URL];
+}
 
-      if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
-          [application openURL:schemeURL options:@{} completionHandler:nil];
-          NSLog(@"Open %@: %d", schemeURL);
-      }
+- (void)openScheme:(NSString *)scheme {
+    UIApplication *application = [UIApplication sharedApplication];
+    NSURL *schemeURL = [NSURL URLWithString:scheme];
+    
+    if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        [application openURL:schemeURL options:@{} completionHandler:nil];
+        NSLog(@"Open %@: %d", schemeURL);
+    }
+    
+}
 
-  }
+@end
 
-  @end
+


### PR DESCRIPTION
Fix for ios FB sharing based off thread: react-native-share/issues/174 

Forked library so i can add this fix in. Thread was based off fix for sharing images. but also fixes sharing of urls. 

@FFS-Evan  looks like you are only one i can add to review. 