### PR TITLE
Updated url composition, because replace was failing on pixel devices

### DIFF
--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -39,9 +39,17 @@ public abstract class SingleShareIntent extends ShareIntent {
                 System.out.println("NOT INSTALLED");
                 String url = "";
                 if(getDefaultWebLink() != null) {
-                    url = getDefaultWebLink()
-                            .replace("{url}",       this.urlEncode( options.getString("url") ) )
-                            .replace("{message}",   this.urlEncode( options.getString("message") ));
+                    // Check if default url has valid replacement strings.
+                    // Replace was failing on pixel phones when there was no match?!
+                    if(getDefaultWebLink().contains("{url}") && getDefaultWebLink().contains("{message}")) {
+                        url = getDefaultWebLink()
+                                .replace("{url}",    this.urlEncode( options.getString("url") ) )
+                                .replace("{message}",this.urlEncode( options.getString("message") ));
+                    } else if(getDefaultWebLink().contains("{url}") && !getDefaultWebLink().contains("{message}")) {
+                        url = getDefaultWebLink().replace("{url}",this.urlEncode( options.getString("url") ) );
+                    } else if(getDefaultWebLink().contains("{message}") && !getDefaultWebLink().contains("{url}")) {
+                        url = getDefaultWebLink().replace("{message}", this.urlEncode(options.getString("message")));
+                    }
                 } else if(getPlayStoreLink() != null) {
                     url = getPlayStoreLink();
                 } else {

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -47,11 +47,11 @@ public abstract class SingleShareIntent extends ShareIntent {
                                 .replace("{url}",    this.urlEncode( options.getString("url")))
                                 .replace("{message}",this.urlEncode( options.getString("message")));
                     }
-                    else if(defaultWebLink.contains("{url}") && !defaultWebLink.contains("{message}"))
+                    else if(defaultWebLink.contains("{url}"))
                     {
                         url = defaultWebLink.replace("{url}", this.urlEncode( options.getString("url")));
                     }
-                    else if(defaultWebLink.contains("{message}") && !defaultWebLink.contains("{url}"))
+                    else if(defaultWebLink.contains("{message}"))
                     {
                         url = defaultWebLink.replace("{message}", this.urlEncode(options.getString("message")));
                     }

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -38,17 +38,22 @@ public abstract class SingleShareIntent extends ShareIntent {
             } else {
                 System.out.println("NOT INSTALLED");
                 String url = "";
-                if(getDefaultWebLink() != null) {
-                    // Check if default url has valid replacement strings.
-                    // Replace was failing on pixel phones when there was no match?!
-                    if(getDefaultWebLink().contains("{url}") && getDefaultWebLink().contains("{message}")) {
-                        url = getDefaultWebLink()
-                                .replace("{url}",    this.urlEncode( options.getString("url") ) )
-                                .replace("{message}",this.urlEncode( options.getString("message") ));
-                    } else if(getDefaultWebLink().contains("{url}") && !getDefaultWebLink().contains("{message}")) {
-                        url = getDefaultWebLink().replace("{url}",this.urlEncode( options.getString("url") ) );
-                    } else if(getDefaultWebLink().contains("{message}") && !getDefaultWebLink().contains("{url}")) {
-                        url = getDefaultWebLink().replace("{message}", this.urlEncode(options.getString("message")));
+                String defaultWebLink = getDefaultWebLink();
+                if(defaultWebLink != null) {
+                    // check if default url has valid replacement strings. Was failing on replace if strings were not present.
+                    if(defaultWebLink.contains("{url}") && defaultWebLink.contains("{message}"))
+                    {
+                        url = defaultWebLink
+                                .replace("{url}",    this.urlEncode( options.getString("url")))
+                                .replace("{message}",this.urlEncode( options.getString("message")));
+                    }
+                    else if(defaultWebLink.contains("{url}") && !defaultWebLink.contains("{message}"))
+                    {
+                        url = defaultWebLink.replace("{url}", this.urlEncode( options.getString("url")));
+                    }
+                    else if(defaultWebLink.contains("{message}") && !defaultWebLink.contains("{url}"))
+                    {
+                        url = defaultWebLink.replace("{message}", this.urlEncode(options.getString("message")));
                     }
                 } else if(getPlayStoreLink() != null) {
                     url = getPlayStoreLink();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-share",
   "description": "Social share, sending simple data to other apps.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-community/react-native-share.git"


### PR DESCRIPTION
For pixel phones .replace was throwing an error when there was no match on the {message} since the getDefaultWebLink() did no have the matching string. 

Updated to check if the weblink contains the value to replace. 

This is a bit concerning why this is failing on the pixel on a very core string function where it should have just been ignored if no watch was found.
